### PR TITLE
Add Playwright E2E tests for Skills page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+playwright-report-*/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qa",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "description": "Repository for all the QA related code and documents",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KotamarthiSriharsha/qa.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/KotamarthiSriharsha/qa/issues"
+  },
+  "homepage": "https://github.com/KotamarthiSriharsha/qa#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,26 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'https://test-saayam.netlify.app',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
+    {
+      name: 'mobile-firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        viewport: { width: 393, height: 851 },
+      },
+    },
+  ],
+});

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -2,25 +2,57 @@ const { defineConfig, devices } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './tests',
+
   fullyParallel: true,
+
+  timeout: 60000,
+
+  expect: {
+    timeout: 10000,
+  },
+
   retries: 1,
+
   reporter: 'list',
+
   use: {
     baseURL: 'https://test-saayam.netlify.app',
     trace: 'on-first-retry',
+    navigationTimeout: 60000,
+    actionTimeout: 15000,
   },
+
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
-    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
-    { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
     {
-      name: 'mobile-firefox',
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'firefox',
       use: {
         ...devices['Desktop Firefox'],
-        viewport: { width: 393, height: 851 },
+        storageState: 'playwright/.auth/user.json',
       },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
   ],
 });

--- a/tests/donate-page.spec.js
+++ b/tests/donate-page.spec.js
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Saayam Donate Page E2E Tests (#45)', () => {
+  test('Donate page loads successfully', async ({ page }) => {
+    await page.goto('/donate');
+
+    await expect(page).toHaveURL(/\/donate$/);
+
+    await expect(
+      page.getByRole('heading', { name: 'Make a donation' })
+    ).toBeVisible();
+  });
+
+  test('Breadcrumb is visible', async ({ page }) => {
+    await page.goto('/donate');
+
+    await expect(
+      page.getByText('Home', { exact: true }).first()
+    ).toBeVisible();
+
+    await expect(
+      page.getByText('Donate', { exact: true }).first()
+    ).toBeVisible();
+  });
+
+  test('All donation buttons are visible', async ({ page }) => {
+    await page.goto('/donate');
+
+    await expect(
+      page.getByRole('button', { name: /PayPal/i })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: /Stripe/i })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: /Charity Navigator/i })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: /Benevity/i })
+    ).toBeVisible();
+  });
+
+  test('FAQ items are visible and clickable', async ({ page }) => {
+    await page.goto('/donate');
+
+    const firstQuestion = page.getByText(
+      'Are donations tax deductible?'
+    );
+
+    const secondQuestion = page.getByText(
+      'How will my donation be used?'
+    );
+
+    const thirdQuestion = page.getByText(
+      'Can I cancel recurring donations?'
+    );
+
+    await expect(firstQuestion).toBeVisible();
+    await firstQuestion.click();
+
+    await expect(secondQuestion).toBeVisible();
+    await secondQuestion.click();
+
+    await expect(thirdQuestion).toBeVisible();
+    await thirdQuestion.click();
+  });
+
+  test('Clicking PayPal opens the PayPal donation page', async ({ page }) => {
+    await page.goto('/donate');
+
+    await page.evaluate(() => {
+      window.openedPayPalUrl = '';
+
+      window.open = (url) => {
+        window.openedPayPalUrl = String(url);
+        return null;
+      };
+    });
+
+    await page.getByRole('button', { name: /PayPal/i }).click();
+
+    await expect
+      .poll(async () => {
+        return await page.evaluate(() => window.openedPayPalUrl);
+      })
+      .toMatch(/paypal\.com/i);
+  });
+
+  test('Clicking Stripe opens the Stripe donation form', async ({ page }) => {
+    await page.goto('/donate');
+
+    await page.getByRole('button', { name: /Stripe/i }).click();
+
+    await expect(
+      page.getByText('One-Time', { exact: true })
+    ).toBeVisible();
+
+    await expect(
+      page.getByText('Monthly', { exact: true })
+    ).toBeVisible();
+
+    await expect(
+      page.locator('button').filter({ hasText: /^Donate$/ }).last()
+    ).toBeVisible();
+  });
+
+  test('Clicking Charity Navigator opens the correct page', async ({ page }) => {
+    await page.goto('/donate');
+
+    const charityNavigatorButton = page.getByRole('button', {
+      name: /Charity Navigator/i
+    });
+
+    const [charityPage] = await Promise.all([
+      page.waitForEvent('popup'),
+      charityNavigatorButton.click()
+    ]);
+
+    await charityPage.waitForLoadState('domcontentloaded');
+
+    await expect(charityPage).toHaveURL(/charitynavigator\.org/i);
+
+    await expect(
+      charityPage
+        .getByRole('heading', { name: 'SAAYAM FOR ALL' })
+        .first()
+    ).toBeVisible();
+  });
+
+  test('Clicking Benevity opens the Benevity information page', async ({ page }) => {
+    await page.goto('/donate');
+
+    await page.getByRole('button', { name: /Benevity/i }).click();
+
+    await expect(
+      page.getByText(/Double Your Impact through Benevity/i)
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(/How to Donate/i)
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('link', { name: /Search on Benevity/i })
+    ).toBeVisible();
+  });
+});

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,0 +1,48 @@
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  setup.setTimeout(60000);
+
+  const email = process.env.SAAYAM_EMAIL;
+  const password = process.env.SAAYAM_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'SAAYAM_EMAIL and SAAYAM_PASSWORD environment variables are required.'
+    );
+  }
+
+  await page.goto('/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  await page
+    .getByPlaceholder(/email/i)
+    .fill(email);
+
+  await page
+    .getByPlaceholder(/password/i)
+    .fill(password);
+
+  await page
+    .getByRole('button', {
+      name: 'Log In',
+      exact: true,
+    })
+    .last()
+    .click();
+
+  await page.waitForURL(
+    url => !url.pathname.includes('/login'),
+    {
+      timeout: 60000,
+    }
+  );
+
+  await page.context().storageState({
+    path: authFile,
+  });
+});

--- a/tests/skills-page.spec.js
+++ b/tests/skills-page.spec.js
@@ -1,0 +1,1003 @@
+import { test, expect } from '@playwright/test';
+
+const categories = {
+  'Clothing Assistance': [
+    'Donate Clothes',
+    'Borrow Clothes',
+    'Emergency Clothing Assistance',
+    'Tailoring',
+  ],
+
+  'Education & Career Support': [
+    'College Application Help',
+    'SOP & Essay Review',
+    'Tutoring',
+    'Scholarship Knowledge',
+    'Study Group Formation',
+    'Career Guidance',
+    'Education Resource Sharing',
+  ],
+
+  'Elderly Community Assistance': [
+    'Senior Relocation Support',
+    'Digital Support for Seniors',
+    'Medication Management',
+    'Transportation for Appointments',
+    'Scheduling Appointments or Tasks',
+  ],
+
+  'Food & Essentials': [
+    'Food Assistance',
+    'Grocery Shopping & Delivery',
+    'Cooking Help',
+  ],
+
+  'Healthcare & Wellness': [
+    'Medical Consultation',
+    'Medicine Delivery',
+    'Mental Wellbeing Support',
+    'Medication Reminders',
+    'Health Education Guidance',
+  ],
+
+  'Housing Assistance': [
+    'Lease Support',
+    'Tenant Rent Support',
+    'Repair & Maintenance Support',
+    'Utilities Setup Support',
+    'Looking for Rental',
+    'Find a Roommate',
+    'Move-in Help',
+  ],
+};
+
+async function openSkillsEditor(page) {
+  await page.goto('/profile', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  const title = page.getByText(
+    'Select Your Skills For Volunteer Assignments',
+    {
+      exact: true,
+    }
+  );
+
+  const skillsButton = page.getByRole('button', {
+    name: 'Skills',
+    exact: true,
+  });
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    // If the editor is already open, we're done.
+    if (await title.isVisible().catch(() => false)) {
+      return;
+    }
+
+    // Wait for the Skills button and click it.
+    await expect(skillsButton).toBeVisible({
+      timeout: 20000,
+    });
+
+    await skillsButton.click({
+      force: true,
+    });
+
+    await page.waitForTimeout(1000);
+
+    // If clicking Skills opened the editor, we're done.
+    if (await title.isVisible().catch(() => false)) {
+      return;
+    }
+
+    // Otherwise try clicking Edit.
+    const editButton = page.getByRole('button', {
+      name: 'Edit',
+      exact: true,
+    });
+
+    if (await editButton.isVisible().catch(() => false)) {
+      await editButton.click({
+        force: true,
+      });
+
+      await page.waitForTimeout(1000);
+
+      if (await title.isVisible().catch(() => false)) {
+        return;
+      }
+    }
+
+    // Retry from a fresh page if necessary.
+    if (attempt < 3) {
+      await page.reload({
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+      });
+    }
+  }
+
+  // Final assertion.
+  await expect(title).toBeVisible({
+    timeout: 20000,
+  });
+}
+
+async function openCategory(page, category) {
+  const categoryText = page
+    .getByText(category, {
+      exact: true,
+    })
+    .first();
+
+  await expect(categoryText).toBeVisible({
+    timeout: 15000,
+  });
+
+  const categoryRow = categoryText.locator('..');
+
+  await categoryRow.scrollIntoViewIfNeeded();
+
+  await categoryRow.hover({
+    force: true,
+  });
+
+  await page.waitForTimeout(500);
+}
+
+async function selectSkill(page, category, skill) {
+  await openCategory(page, category);
+
+  const skillText = page
+    .getByText(skill, {
+      exact: true,
+    })
+    .first();
+
+  await expect(skillText).toBeVisible({
+    timeout: 15000,
+  });
+
+  const skillRow = skillText.locator('..');
+
+  await skillRow.scrollIntoViewIfNeeded();
+
+  await skillRow.click({
+    force: true,
+  });
+
+  await page.waitForTimeout(500);
+}
+
+test.describe('Saayam Skills Page E2E Tests', () => {
+  test.describe.configure({
+    timeout: 60000,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await openSkillsEditor(page);
+  });
+
+  test('TC_SK_001 - User can open Skills page from Profile', async ({ page }) => {
+    await expect(page).toHaveURL(/\/profile/);
+
+    await expect(
+      page.getByText(
+        'Select Your Skills For Volunteer Assignments',
+        {
+          exact: true,
+        }
+      )
+    ).toBeVisible();
+  });
+
+  test('TC_SK_002 - Page title is displayed correctly', async ({ page }) => {
+    await expect(
+      page.getByText(
+        'Select Your Skills For Volunteer Assignments',
+        {
+          exact: true,
+        }
+      )
+    ).toBeVisible();
+  });
+
+  test('TC_SK_003 - Helper text is displayed', async ({ page }) => {
+    await expect(
+      page.getByText(
+        'Hover to explore categories, click to select skills',
+        {
+          exact: true,
+        }
+      )
+    ).toBeVisible();
+  });
+
+  test('TC_SK_004 - All main skill categories are displayed', async ({ page }) => {
+    const categoryNames = [
+      'Clothing Assistance',
+      'Education & Career Support',
+      'Elderly Community Assistance',
+      'Food & Essentials',
+      'Healthcare & Wellness',
+      'Housing Assistance',
+      'General',
+    ];
+
+    for (const category of categoryNames) {
+      await expect(
+        page
+          .getByText(category, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible();
+    }
+  });
+
+  test('TC_SK_005 - Category arrow indicators are visible', async ({ page }) => {
+    const categoryNames = [
+      'Clothing Assistance',
+      'Education & Career Support',
+      'Elderly Community Assistance',
+      'Food & Essentials',
+      'Healthcare & Wellness',
+      'Housing Assistance',
+    ];
+
+    for (const category of categoryNames) {
+      const categoryText = page
+        .getByText(category, {
+          exact: true,
+        })
+        .first();
+
+      await expect(categoryText).toBeVisible();
+
+      const categoryRow = categoryText.locator('..');
+
+      const hasIndicator = await categoryRow.evaluate(
+        element => {
+          const text = element.textContent || '';
+
+          const beforeContent = window
+            .getComputedStyle(element, '::before')
+            .getPropertyValue('content');
+
+          const afterContent = window
+            .getComputedStyle(element, '::after')
+            .getPropertyValue('content');
+
+          return (
+            text.includes('>') ||
+            beforeContent.includes('>') ||
+            afterContent.includes('>')
+          );
+        }
+      );
+
+      expect(hasIndicator).toBe(true);
+    }
+  });
+
+  test('TC_SK_006 - Clothing Assistance sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Clothing Assistance'
+    );
+
+    for (
+      const skill of categories[
+        'Clothing Assistance'
+      ]
+    ) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test('TC_SK_007 - Education and Career Support sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Education & Career Support'
+    );
+
+    for (
+      const skill of categories[
+        'Education & Career Support'
+      ]
+    ) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test('TC_SK_008 - Elderly Community Assistance sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Elderly Community Assistance'
+    );
+
+    const expectedSkills = [
+      'Senior Relocation Support',
+      'Digital Support for Seniors',
+      'Medication Management',
+      'Transportation for Appointments',
+      'Scheduling Appointments or Tasks',
+    ];
+
+    for (const skill of expectedSkills) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+
+    const visibleSkillTexts = await page
+      .locator('main')
+      .getByText(
+        /Support|Management|Appointments|Transportation|Setup/i
+      )
+      .allTextContents();
+
+    expect(
+      visibleSkillTexts.length
+    ).toBeGreaterThanOrEqual(5);
+  });
+
+  test('TC_SK_009 - Food and Essentials sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Food & Essentials'
+    );
+
+    for (
+      const skill of categories[
+        'Food & Essentials'
+      ]
+    ) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test('TC_SK_010 - Healthcare and Wellness sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Healthcare & Wellness'
+    );
+
+    for (
+      const skill of categories[
+        'Healthcare & Wellness'
+      ]
+    ) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test('TC_SK_011 - Housing Assistance sub-skills are displayed', async ({ page }) => {
+    await openCategory(
+      page,
+      'Housing Assistance'
+    );
+
+    for (
+      const skill of categories[
+        'Housing Assistance'
+      ]
+    ) {
+      await expect(
+        page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first()
+      ).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test('TC_SK_012 - Hovered category is highlighted', async ({ page }) => {
+    const category = page
+      .getByText(
+        'Clothing Assistance',
+        {
+          exact: true,
+        }
+      )
+      .first();
+
+    const categoryRow = category.locator('..');
+
+    const backgroundBefore =
+      await categoryRow.evaluate(element => {
+        return window.getComputedStyle(
+          element
+        ).backgroundColor;
+      });
+
+    await categoryRow.hover({
+      force: true,
+    });
+
+    await page.waitForTimeout(500);
+
+    const backgroundAfter =
+      await categoryRow.evaluate(element => {
+        return window.getComputedStyle(
+          element
+        ).backgroundColor;
+      });
+
+    expect(backgroundAfter).not.toBe(
+      backgroundBefore
+    );
+  });
+
+  test('TC_SK_013 - Sub-skill panel changes when category changes', async ({ page }) => {
+    await openCategory(
+      page,
+      'Clothing Assistance'
+    );
+
+    await expect(
+      page
+        .getByText('Donate Clothes', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible();
+
+    await openCategory(
+      page,
+      'Food & Essentials'
+    );
+
+    await expect(
+      page
+        .getByText('Food Assistance', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByText(
+          'Grocery Shopping & Delivery',
+          {
+            exact: true,
+          }
+        )
+        .first()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_014 - Category hover provides additional information', async ({ page }) => {
+    await openCategory(
+      page,
+      'Education & Career Support'
+    );
+
+    await expect(
+      page
+        .getByText(
+          'College Application Help',
+          {
+            exact: true,
+          }
+        )
+        .first()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_015 - User can select a sub-skill', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Clothing Assistance',
+      'Donate Clothes'
+    );
+
+    await expect(
+      page
+        .getByText('Donate Clothes', {
+          exact: true,
+        })
+        .last()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_016 - Selected skill appears in Selected Skills section', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Food & Essentials',
+      'Food Assistance'
+    );
+
+    await expect(
+      page.getByText('Selected Skills', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    const matchingSkills = page.getByText(
+      'Food Assistance',
+      {
+        exact: true,
+      }
+    );
+
+    expect(
+      await matchingSkills.count()
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  test('TC_SK_017 - Multiple skills from the same category can be selected', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Clothing Assistance',
+      'Donate Clothes'
+    );
+
+    await selectSkill(
+      page,
+      'Clothing Assistance',
+      'Tailoring'
+    );
+
+    await expect(
+      page
+        .getByText('Donate Clothes', {
+          exact: true,
+        })
+        .last()
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByText('Tailoring', {
+          exact: true,
+        })
+        .last()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_018 - Skills from different categories can be selected', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Clothing Assistance',
+      'Donate Clothes'
+    );
+
+    await selectSkill(
+      page,
+      'Food & Essentials',
+      'Cooking Help'
+    );
+
+    await expect(
+      page
+        .getByText('Donate Clothes', {
+          exact: true,
+        })
+        .last()
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByText('Cooking Help', {
+          exact: true,
+        })
+        .last()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_019 - Selected skill can be deselected', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Clothing Assistance',
+      'Borrow Clothes'
+    );
+
+    await openCategory(
+      page,
+      'Clothing Assistance'
+    );
+
+    const borrowClothes = page
+      .getByText('Borrow Clothes', {
+        exact: true,
+      })
+      .first();
+
+    await borrowClothes
+      .locator('..')
+      .click({
+        force: true,
+      });
+
+    const selectedSkillsSection = page
+      .getByText('Selected Skills', {
+        exact: true,
+      })
+      .locator('..');
+
+    await expect(
+      selectedSkillsSection.getByText(
+        'Borrow Clothes',
+        {
+          exact: true,
+        }
+      )
+    ).toHaveCount(0);
+  });
+
+  test('TC_SK_020 - General skill is selected by default', async ({ page }) => {
+    await expect(
+      page.getByText('Selected Skills', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByText('General', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible();
+  });
+
+  test('TC_SK_021 - General is selected when no other skills are chosen', async ({ page }) => {
+    await expect(
+      page
+        .getByText('General', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Save',
+        exact: true,
+      })
+    ).toBeEnabled();
+  });
+
+  test('TC_SK_022 - Save button is visible', async ({ page }) => {
+    await expect(
+      page.getByRole('button', {
+        name: 'Save',
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  test('TC_SK_023 - Cancel button is visible', async ({ page }) => {
+    await expect(
+      page.getByRole('button', {
+        name: 'Cancel',
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  test('TC_SK_024 - Save selected skills', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Food & Essentials',
+      'Cooking Help'
+    );
+
+    const saveButton = page.getByRole(
+      'button',
+      {
+        name: 'Save',
+        exact: true,
+      }
+    );
+
+    await expect(saveButton).toBeVisible();
+    await expect(saveButton).toBeEnabled();
+
+    await saveButton.click({
+      force: true,
+    });
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      })
+    ).toBeVisible({
+      timeout: 20000,
+    });
+  });
+
+  test('TC_SK_025 - Save with no selected skills uses General by default', async ({ page }) => {
+    const saveButton = page.getByRole(
+      'button',
+      {
+        name: 'Save',
+        exact: true,
+      }
+    );
+
+    await saveButton.click({
+      force: true,
+    });
+
+    await expect(
+      page
+        .getByText('General', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible({
+      timeout: 20000,
+    });
+  });
+
+  test('TC_SK_026 - Cancel discards unsaved changes', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Healthcare & Wellness',
+      'Medication Reminders'
+    );
+
+    await page
+      .getByRole('button', {
+        name: 'Cancel',
+        exact: true,
+      })
+      .click({
+        force: true,
+      });
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      })
+    ).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page
+      .getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      })
+      .click({
+        force: true,
+      });
+
+    await openCategory(
+      page,
+      'Healthcare & Wellness'
+    );
+
+    const selectedSkillsSection = page
+      .getByText('Selected Skills', {
+        exact: true,
+      })
+      .locator('..');
+
+    await expect(
+      selectedSkillsSection.getByText(
+        'Medication Reminders',
+        {
+          exact: true,
+        }
+      )
+    ).toHaveCount(0);
+  });
+
+  test('TC_SK_027 - Saved skills remain after refresh', async ({ page }) => {
+    await selectSkill(
+      page,
+      'Housing Assistance',
+      'Move-in Help'
+    );
+
+    const saveButton = page.getByRole(
+      'button',
+      {
+        name: 'Save',
+        exact: true,
+      }
+    );
+
+    await saveButton.click({
+      force: true,
+    });
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      })
+    ).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.reload({
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
+
+    const skillsButton = page.getByRole(
+      'button',
+      {
+        name: 'Skills',
+        exact: true,
+      }
+    );
+
+    await expect(skillsButton).toBeVisible({
+      timeout: 20000,
+    });
+
+    await skillsButton.click({
+      force: true,
+    });
+
+    const editButton = page.getByRole(
+      'button',
+      {
+        name: 'Edit',
+        exact: true,
+      }
+    );
+
+    await expect(editButton).toBeVisible({
+      timeout: 20000,
+    });
+
+    await editButton.click({
+      force: true,
+    });
+
+    await openCategory(
+      page,
+      'Housing Assistance'
+    );
+
+    await expect(
+      page
+        .getByText('Move-in Help', {
+          exact: true,
+        })
+        .first()
+    ).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('TC_SK_028 - Main card UI elements are aligned and visible', async ({ page }) => {
+    await expect(
+      page
+        .getByText(
+          'Clothing Assistance',
+          {
+            exact: true,
+          }
+        )
+        .first()
+    ).toBeVisible();
+
+    await expect(
+      page.getByText('Selected Skills', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Save',
+        exact: true,
+      })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Cancel',
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  test('TC_SK_029 - Profile sidebar remains visible with Skills selected', async ({ page }) => {
+    await expect(
+      page.getByRole('button', {
+        name: 'Your Profile',
+        exact: true,
+      })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Skills',
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  test('TC_SK_030 - No duplicate sub-skills appear within a category', async ({ page }) => {
+    const categoryNames = [
+      'Clothing Assistance',
+      'Education & Career Support',
+      'Elderly Community Assistance',
+      'Food & Essentials',
+      'Healthcare & Wellness',
+      'Housing Assistance',
+    ];
+
+    for (const category of categoryNames) {
+      await openCategory(page, category);
+
+      const expectedSkills =
+        categories[category];
+
+      const visibleSkills = [];
+
+      for (const skill of expectedSkills) {
+        const skillLocator = page
+          .getByText(skill, {
+            exact: true,
+          })
+          .first();
+
+        if (await skillLocator.isVisible()) {
+          visibleSkills.push(skill);
+        }
+      }
+
+      const uniqueSkills = new Set(
+        visibleSkills
+      );
+
+      expect(uniqueSkills.size).toBe(
+        visibleSkills.length
+      );
+    }
+  });
+})


### PR DESCRIPTION
## Summary

Added Playwright end-to-end test coverage for the Saayam Profile Skills page.

## Test coverage

- Profile navigation to the Skills page
- Page title, helper text, categories, and indicators
- Category hover behavior and sub-skill panel updates
- Skill selection and deselection
- Multiple selections from the same and different categories
- Default General skill behavior
- Save and Cancel actions
- Saved-skill persistence after refresh
- Sidebar visibility and UI element checks
- Duplicate sub-skill validation

## Browser coverage

- Chromium
- Firefox
- WebKit

## Execution result

- 90 Skills Page tests passed across Chromium, Firefox, and WebKit
- 1 authentication setup test passed
- 91 total tests passed

## Files added or updated

- `tests/skills-page.spec.js`
- `tests/setup/auth.setup.js`
- `playwright.config.cjs`
[Playwright Test Report 50.pdf](https://github.com/user-attachments/files/30110537/Playwright.Test.Report.50.pdf)
