### PR TITLE
Add Playwright E2E tests for Profile Preferences page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report*/
+test-results/
+.env
+playwright/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qa",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "description": "Repository for all the QA related code and documents",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KotamarthiSriharsha/qa.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/KotamarthiSriharsha/qa/issues"
+  },
+  "homepage": "https://github.com/KotamarthiSriharsha/qa#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,58 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+
+  fullyParallel: true,
+
+  timeout: 60000,
+
+  expect: {
+    timeout: 10000,
+  },
+
+  retries: 1,
+
+  reporter: 'list',
+
+  use: {
+    baseURL: 'https://test-saayam.netlify.app',
+    trace: 'on-first-retry',
+    navigationTimeout: 60000,
+    actionTimeout: 15000,
+  },
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/profile-availability.spec.js
+++ b/tests/profile-availability.spec.js
@@ -1,0 +1,65 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Issue #51 - Profile Availability', () => {
+  test('TC_51_01 - authenticated user can access Profile Availability', async ({
+    page,
+  }) => {
+    // Authentication is handled by auth.setup.js
+    await page.goto('https://test-saayam.netlify.app', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Click the account/profile icon in the top-right corner
+    const accountMenuButton = page
+      .locator(
+        'button[aria-label*="profile" i], ' +
+        'button[aria-label*="account" i], ' +
+        '[title*="profile" i], ' +
+        '[title*="account" i]'
+      )
+      .last();
+
+    await expect(accountMenuButton).toBeVisible({ timeout: 20000 });
+    await accountMenuButton.click();
+
+    // Click Profile from the dropdown
+    const profileMenuItem = page.getByText('Profile', {
+      exact: true,
+    });
+
+    await expect(profileMenuItem).toBeVisible({ timeout: 10000 });
+    await profileMenuItem.click();
+
+    // Verify the Profile page loaded
+    const yourProfileButton = page.getByRole('button', {
+      name: 'Your Profile',
+      exact: true,
+    });
+
+    await expect(yourProfileButton).toBeVisible({ timeout: 20000 });
+
+    // Click Availability in the left sidebar
+    const availabilityOption = page
+      .getByText('Availability', { exact: true })
+      .first();
+
+    await expect(availabilityOption).toBeVisible({ timeout: 20000 });
+    await availabilityOption.click();
+
+    // Verify Availability content
+    await expect(
+      page.getByText('Timezone', { exact: true })
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(
+      page.getByText('No availability slots configured', { exact: true })
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      })
+    ).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/tests/profile-preferences.spec.js
+++ b/tests/profile-preferences.spec.js
@@ -1,0 +1,471 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Profile Preferences Page', () => {
+  async function firstVisible(locator) {
+    const count = await locator.count();
+
+    for (let index = 0; index < count; index += 1) {
+      const element = locator.nth(index);
+
+      if (await element.isVisible().catch(() => false)) {
+        return element;
+      }
+    }
+
+    return null;
+  }
+
+  async function openAccountMenu(page) {
+    const viewport = page.viewportSize();
+
+    if (!viewport) {
+      throw new Error('Unable to determine the browser viewport size.');
+    }
+
+    const candidates = page.locator(
+      [
+        'button',
+        '[role="button"]',
+        'a',
+        '[tabindex="0"]',
+        'svg',
+      ].join(','),
+    );
+
+    const candidateCount = await candidates.count();
+    const topRightCandidates = [];
+
+    for (let index = 0; index < candidateCount; index += 1) {
+      const candidate = candidates.nth(index);
+
+      if (!(await candidate.isVisible().catch(() => false))) {
+        continue;
+      }
+
+      const box = await candidate.boundingBox();
+
+      if (!box) {
+        continue;
+      }
+
+      const isNearTop = box.y < 180;
+      const isNearRight = box.x > viewport.width * 0.65;
+
+      if (isNearTop && isNearRight) {
+        topRightCandidates.push({
+          locator: candidate,
+          x: box.x,
+          y: box.y,
+        });
+      }
+    }
+
+    topRightCandidates.sort((first, second) => {
+      if (second.x !== first.x) {
+        return second.x - first.x;
+      }
+
+      return first.y - second.y;
+    });
+
+    for (const candidate of topRightCandidates) {
+      await candidate.locator
+        .click({
+          force: true,
+        })
+        .catch(() => {});
+
+      const profileMenuItem = page.getByText('Profile', {
+        exact: true,
+      });
+
+      try {
+        await profileMenuItem.first().waitFor({
+          state: 'visible',
+          timeout: 3000,
+        });
+
+        return profileMenuItem.first();
+      } catch {
+        await page.keyboard.press('Escape').catch(() => {});
+      }
+    }
+
+    throw new Error(
+      'Unable to open the account dropdown containing Profile and Logout.',
+    );
+  }
+
+  async function openPreferencesPage(page) {
+    await page.goto('/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+
+    await expect(page).not.toHaveURL(/login/i, {
+      timeout: 30000,
+    });
+
+    await expect(
+      page.getByText('Home', {
+        exact: true,
+      }),
+    ).toBeVisible({
+      timeout: 30000,
+    });
+
+    const profileMenuItem = await openAccountMenu(page);
+
+    await expect(profileMenuItem).toBeVisible({
+      timeout: 10000,
+    });
+
+    await profileMenuItem.click();
+
+    const personalInformation = await firstVisible(
+      page.getByText('Personal Information', {
+        exact: true,
+      }),
+    );
+
+    if (!personalInformation) {
+      throw new Error(
+        'Profile page did not load: Personal Information was not visible.',
+      );
+    }
+
+    await expect(personalInformation).toBeVisible({
+      timeout: 30000,
+    });
+
+    const preferencesSidebarItem = await firstVisible(
+      page.getByText('Preferences', {
+        exact: true,
+      }),
+    );
+
+    if (!preferencesSidebarItem) {
+      throw new Error(
+        'Preferences was not found in the Profile sidebar.',
+      );
+    }
+
+    await preferencesSidebarItem.click();
+
+    await expect(
+      page.getByText('Default Dashboard View', {
+        exact: true,
+      }),
+    ).toBeVisible({
+      timeout: 30000,
+    });
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await openPreferencesPage(page);
+  });
+
+  test(
+    'TC_PP_001 - authenticated user can access Profile Preferences',
+    async ({ page }) => {
+      await expect(
+        page.getByText('Default Dashboard View', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole('button', {
+          name: 'Edit',
+          exact: true,
+        }),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'TC_PP_002 - Preferences page displays all expected sections',
+    async ({ page }) => {
+      const expectedSections = [
+        'Default Dashboard View',
+        'First Language Preference',
+        'Second Language Preference',
+        'Third Language Preference',
+        'Email Communication Preference',
+        'Phone Communication Preference',
+        'Timezone',
+        'Receive Emergency Notifications',
+      ];
+
+      for (const section of expectedSections) {
+        await expect(
+          page.getByText(section, {
+            exact: true,
+          }),
+          `${section} should be displayed`,
+        ).toBeVisible();
+      }
+    },
+  );
+
+  test(
+    'TC_PP_003 - default dashboard preference is displayed',
+    async ({ page }) => {
+      await expect(
+        page.getByText('Default Dashboard View', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(/Beneficiary Dashboard/i),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'TC_PP_004 - language preference sections are displayed',
+    async ({ page }) => {
+      const languageFields = [
+        'First Language Preference',
+        'Second Language Preference',
+        'Third Language Preference',
+      ];
+
+      for (const field of languageFields) {
+        await expect(
+          page.getByText(field, {
+            exact: true,
+          }),
+        ).toBeVisible();
+      }
+    },
+  );
+
+  test(
+    'TC_PP_005 - email communication preference is displayed',
+    async ({ page }) => {
+      await expect(
+        page.getByText('Email Communication Preference', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(/Primary Email:/i),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'TC_PP_006 - phone communication preference is displayed',
+    async ({ page }) => {
+      await expect(
+        page.getByText('Phone Communication Preference', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(/Primary Phone:/i),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'TC_PP_007 - timezone is displayed with a friendly label',
+    async ({ page }) => {
+      const timezoneLabel = page.getByText('Timezone', {
+        exact: true,
+      });
+
+      await expect(timezoneLabel).toBeVisible();
+
+      const timezoneSection = timezoneLabel.locator('..');
+
+      await expect(timezoneSection).toBeVisible();
+
+      const timezoneText = await timezoneSection.textContent();
+
+      expect(timezoneText).toBeTruthy();
+
+      expect(
+        timezoneText,
+        'Timezone value should include a readable timezone name',
+      ).toMatch(/[A-Za-z]+(?:\/[A-Za-z_]+)?/);
+
+      expect(
+        timezoneText,
+        'Timezone value should include UTC or a UTC offset',
+      ).toMatch(/UTC(?:[+-]\d{2}:\d{2})?/);
+    },
+  );
+
+  test(
+    'TC_PP_008 - emergency notification preference is displayed',
+    async ({ page }) => {
+      await expect(
+        page.getByText('Receive Emergency Notifications', {
+          exact: true,
+        }),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'TC_PP_009 - Edit button is visible and enabled',
+    async ({ page }) => {
+      const editButton = page.getByRole('button', {
+        name: 'Edit',
+        exact: true,
+      });
+
+      await expect(editButton).toBeVisible();
+      await expect(editButton).toBeEnabled();
+    },
+  );
+
+  test(
+    'TC_PP_010 - Profile sidebar options remain visible',
+    async ({ page }) => {
+      const sidebarItems = [
+        'Your Profile',
+        'Personal Information',
+        'Identity Document',
+        'Change Password',
+        'Organization Details',
+        'Skills',
+        'Availability',
+        'Preferences',
+        'Sign Off',
+      ];
+
+      for (const item of sidebarItems) {
+        const visibleItem = await firstVisible(
+          page.getByText(item, {
+            exact: true,
+          }),
+        );
+
+        expect(
+          visibleItem,
+          `${item} should be visible in the Profile sidebar`,
+        ).not.toBeNull();
+
+        await expect(visibleItem).toBeVisible();
+      }
+    },
+  );
+
+  test(
+    'TC_PP_011 - Preferences page regression check',
+    async ({ page }) => {
+      const expectedContent = [
+        'Default Dashboard View',
+        'Email Communication Preference',
+        'Phone Communication Preference',
+        'Timezone',
+        'Receive Emergency Notifications',
+      ];
+
+      for (const content of expectedContent) {
+        await expect(
+          page.getByText(content, {
+            exact: true,
+          }),
+        ).toBeVisible();
+      }
+
+      await expect(
+        page.getByRole('button', {
+          name: 'Edit',
+          exact: true,
+        }),
+      ).toBeEnabled();
+    },
+  );
+
+  test.skip(
+    'TC_PP_012 - changing timezone updates Availability immediately',
+    async () => {
+      /*
+       * Requires the editable Preferences form,
+       * timezone selector and Save button.
+       */
+    },
+  );
+
+  test.skip(
+    'TC_PP_013 - notification channel toggles are disabled when master is off',
+    async () => {
+      /*
+       * Requires the editable notification controls.
+       */
+    },
+  );
+
+  test.skip(
+    'TC_PP_014 - at least 10 friendly timezone labels are available',
+    async () => {
+      /*
+       * Requires the timezone dropdown options.
+       */
+    },
+  );
+
+  test.skip(
+    'TC_PP_015 - valid email verification code succeeds',
+    async () => {
+      // Requires the email verification UI and a valid test code.
+    },
+  );
+
+  test.skip(
+    'TC_PP_016 - expired email verification code is rejected',
+    async () => {
+      // Requires an expired verification code.
+    },
+  );
+
+  test.skip(
+    'TC_PP_017 - incorrect email verification code is rejected',
+    async () => {
+      // Requires access to the email verification flow.
+    },
+  );
+
+  test.skip(
+    'TC_PP_018 - phone OTP is delivered successfully',
+    async () => {
+      // Requires test SMS or OTP service access.
+    },
+  );
+
+  test.skip(
+    'TC_PP_019 - incorrect phone OTP is rejected',
+    async () => {
+      // Requires access to the phone OTP flow.
+    },
+  );
+
+  test.skip(
+    'TC_PP_020 - phone OTP can be resent',
+    async () => {
+      // Requires test OTP delivery support.
+    },
+  );
+
+  test.skip(
+    'TC_PP_021 - verification badge appears after successful verification',
+    async () => {
+      // Requires the complete verification flow.
+    },
+  );
+
+  test.skip(
+    'TC_PP_022 - verification badge does not appear after failed verification',
+    async () => {
+      // Requires the complete verification flow.
+    },
+  );
+});

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,0 +1,48 @@
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  setup.setTimeout(60000);
+
+  const email = process.env.SAAYAM_EMAIL;
+  const password = process.env.SAAYAM_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'SAAYAM_EMAIL and SAAYAM_PASSWORD environment variables are required.'
+    );
+  }
+
+  await page.goto('/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  await page
+    .getByPlaceholder(/email/i)
+    .fill(email);
+
+  await page
+    .getByPlaceholder(/password/i)
+    .fill(password);
+
+  await page
+    .getByRole('button', {
+      name: 'Log In',
+      exact: true,
+    })
+    .last()
+    .click();
+
+  await page.waitForURL(
+    url => !url.pathname.includes('/login'),
+    {
+      timeout: 60000,
+    }
+  );
+
+  await page.context().storageState({
+    path: authFile,
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds Playwright end-to-end test coverage for the Profile → Preferences page.

The tests reuse the existing authentication setup and validate navigation from the authenticated Home page to the Profile page and then to Preferences.

## Implemented coverage

- Verified authenticated access to Profile → Preferences.
- Verified all expected Preferences sections are displayed.
- Verified the default dashboard preference is displayed.
- Verified first, second, and third language preference sections.
- Verified email communication preference information.
- Verified phone communication preference information.
- Verified timezone information is displayed with a readable timezone name and UTC value/offset.
- Verified emergency notification preference visibility.
- Verified the Edit button is visible and enabled.
- Verified Profile sidebar navigation items remain visible.
- Added a general Preferences page regression test.

## Browser coverage

The test suite was executed across all configured browser projects:

- Chromium
- Firefox
- WebKit

## Execution results

- 34 passed
  - 1 authentication setup test
  - 33 browser test executions
- 33 skipped
  - 11 pending test scenarios across 3 browsers
- 0 failed

## Skipped-test explanation

The skipped scenarios are documented in the test file and were not falsely marked as passing. They require additional UI access, backend test support, or external email/SMS verification infrastructure.

### TC_PP_012 — Changing timezone updates Availability immediately

This test requires interacting with the editable timezone selector, saving a different timezone, navigating to Availability, and confirming that the new timezone appears without a manual refresh.

It remains skipped because the current automation was created from the read-only Preferences view, and the exact timezone edit control, save behavior, and synchronization mechanism still need to be inspected and confirmed.

Frontend support needed:
- Stable locator for the timezone selector.
- Confirmed Save/Update behavior.
- Confirmation of how the updated timezone appears on Availability.

Backend support needed:
- A reliable test account whose timezone can be changed repeatedly.
- Confirmation that the timezone update API persists and returns the new value immediately.

### TC_PP_013 — Notification channels are disabled when the master toggle is off

This test should turn off the master emergency-notification setting and verify that dependent notification-channel controls become disabled.

It remains skipped because the read-only page does not show the editable master toggle or subordinate channel controls.

Frontend support needed:
- Stable identifiers for the master notification toggle.
- Stable identifiers for dependent Email, SMS, Push, Phone, or other channel controls.
- Confirmation of the expected disabled-state behavior.

Backend support needed:
- Confirmation of the preference model and which channel values should be retained or cleared when the master toggle is turned off.

### TC_PP_014 — At least 10 friendly timezone labels are available

This test should open the timezone selector and verify at least 10 options using friendly labels such as an IANA timezone, UTC offset, and readable timezone description.

It remains skipped because the timezone dropdown options were not available in the supplied read-only view.

Frontend support needed:
- Stable locator for the timezone dropdown.
- Confirmation of the intended label format.
- Confirmation that virtualization or lazy loading is not hiding options from automation.

Backend support needed:
- Confirmation of the supported timezone list and expected label data.

### TC_PP_015 — Valid email verification code succeeds

This test requires requesting or receiving a valid email verification code, entering it, and verifying that the account becomes email-verified.

It remains skipped because Playwright currently has no test inbox, backend test endpoint, or deterministic valid verification code.

Frontend support needed:
- Stable locators for requesting and entering the verification code.
- Confirmation of the success message and verified-state UI.

Backend support needed:
- A test-only verification-code mechanism or email inbox.
- A deterministic way to retrieve a valid code.
- A test account that can be reset to an unverified state.

### TC_PP_016 — Expired email verification code is rejected

This test should submit an expired email verification code and verify that the application displays the appropriate error without marking the email as verified.

It remains skipped because there is no controlled way to generate or retrieve an expired code.

Frontend support needed:
- Confirmation of the expected expired-code error message.
- Confirmation that the verification badge remains absent.

Backend support needed:
- A test endpoint or fixture that creates an expired verification code.
- A resettable unverified test account.

### TC_PP_017 — Incorrect email verification code is rejected

This test should enter an incorrect email verification code and verify that the code is rejected and the account remains unverified.

It remains skipped because the complete email-verification flow and stable test data are not currently available to the automated suite.

Frontend support needed:
- Stable code-input and Submit/Verify locators.
- Confirmation of the incorrect-code error message.

Backend support needed:
- A resettable unverified test account.
- Confirmation of retry limits and lockout behavior.

### TC_PP_018 — Phone OTP is delivered successfully

This test should request a phone OTP and verify that the OTP delivery request succeeds.

It remains skipped because the automation does not have access to a test SMS inbox or backend OTP retrieval mechanism.

Frontend support needed:
- Stable Send OTP control.
- Confirmation of the delivery-success message or state.

Backend support needed:
- Test phone number support.
- Mock SMS provider, test inbox, or OTP retrieval endpoint.
- Protection against sending real SMS messages during automated runs.

### TC_PP_019 — Incorrect phone OTP is rejected

This test should submit an invalid phone OTP and verify that the application displays an error and does not mark the phone number as verified.

It remains skipped because the phone-verification UI and deterministic test state are not yet available.

Frontend support needed:
- Stable OTP input and Verify button locators.
- Confirmation of the expected invalid-OTP error message.

Backend support needed:
- Resettable unverified phone state.
- Confirmation of OTP retry limits and expiration behavior.

### TC_PP_020 — Phone OTP can be resent

This test should request an OTP, use the Resend action, and confirm that a new OTP is generated or that a resend confirmation is displayed.

It remains skipped because there is no test SMS infrastructure for validating delivery or confirming that the resent OTP differs from the original.

Frontend support needed:
- Stable Resend OTP locator.
- Confirmation of cooldown and disabled-state behavior.
- Confirmation of the resend-success message.

Backend support needed:
- Test OTP retrieval.
- Confirmation that the old OTP becomes invalid after resending.
- A mechanism to bypass or control resend throttling in the test environment.

### TC_PP_021 — Verification badge appears after successful verification

This test should complete successful email or phone verification and verify that the corresponding verification badge appears.

It remains skipped because it depends on completing one of the external verification workflows.

Frontend support needed:
- Stable locator and expected text/icon for the verification badge.
- Confirmation of whether the badge appears immediately or after data reload.

Backend support needed:
- Deterministic email or phone verification support.
- Resettable test-account verification state.

### TC_PP_022 — Verification badge does not appear after failed verification

This test should submit an invalid or expired verification code and confirm that no verification badge is shown.

It remains skipped because the negative verification workflows cannot currently be placed into a controlled test state.

Frontend support needed:
- Stable badge locator.
- Confirmation of the expected UI after failed verification.

Backend support needed:
- Resettable unverified account state.
- Deterministic invalid and expired verification-code scenarios.

## Test report
[profile-preferences-playwright-report.pdf](https://github.com/user-attachments/files/30326907/profile-preferences-playwright-report.pdf)
