### PR TITLE
Add Playwright E2E tests for Profile Sign Off page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright generated files
+node_modules/
+playwright-report/
+playwright-report-*/
+test-results/
+playwright/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qa",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "description": "Repository for all the QA related code and documents",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KotamarthiSriharsha/qa.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/KotamarthiSriharsha/qa/issues"
+  },
+  "homepage": "https://github.com/KotamarthiSriharsha/qa#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,58 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+
+  fullyParallel: true,
+
+  timeout: 60000,
+
+  expect: {
+    timeout: 10000,
+  },
+
+  retries: 1,
+
+  reporter: 'list',
+
+  use: {
+    baseURL: 'https://test-saayam.netlify.app',
+    trace: 'on-first-retry',
+    navigationTimeout: 60000,
+    actionTimeout: 15000,
+  },
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/profile-sign-off.spec.js
+++ b/tests/profile-sign-off.spec.js
@@ -1,0 +1,268 @@
+import { test, expect } from '@playwright/test';
+
+const SIGN_OFF_HEADING = 'Sign Off';
+const DELETE_CHECKBOX_NAME = /I want to delete my account/i;
+
+async function openSignOffPage(page) {
+  await page.goto('/profile', {
+    waitUntil: 'domcontentloaded',
+  });
+
+  const signOffLink = page
+    .getByText('Sign Off', { exact: true })
+    .last();
+
+  await expect(signOffLink).toBeVisible();
+  await signOffLink.click();
+
+  await expect(getReasonTextarea(page)).toBeVisible();
+
+  await expect(
+    page.getByRole('heading', {
+      name: SIGN_OFF_HEADING,
+      exact: true,
+    })
+  ).toBeVisible();
+}
+
+function getReasonTextarea(page) {
+  return page.locator('#reasonForLeaving');
+}
+
+function getDeletionCheckbox(page) {
+  return page.getByRole('checkbox', {
+    name: DELETE_CHECKBOX_NAME,
+  });
+}
+
+function getCancelButton(page) {
+  return page
+    .getByRole('button', {
+      name: 'Cancel',
+      exact: true,
+    })
+    .first();
+}
+
+function getSubmitButton(page) {
+  return page.getByRole('button', {
+    name: 'Submit',
+    exact: true,
+  });
+}
+
+function getCharacterCounter(page) {
+  return page.getByText(/^\d+\/500 characters$/);
+}
+
+test.describe('Profile - Sign Off', () => {
+  test.beforeEach(async ({ page }) => {
+    await openSignOffPage(page);
+  });
+
+  test('FT-01 - Verify initial state of the Sign Off page', async ({
+    page,
+  }) => {
+    const textarea = getReasonTextarea(page);
+    const checkbox = getDeletionCheckbox(page);
+    const cancelButton = getCancelButton(page);
+    const submitButton = getSubmitButton(page);
+
+    await expect(
+      page.getByText('Account Deletion', {
+        exact: true,
+      })
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(
+        /This action will permanently delete your account and all associated data/i
+      )
+    ).toBeVisible();
+
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue('');
+    await expect(textarea).toHaveAttribute('maxlength', '500');
+
+    await expect(getCharacterCounter(page)).toHaveText(
+      '0/500 characters'
+    );
+
+    await expect(checkbox).not.toBeChecked();
+    await expect(cancelButton).toBeEnabled();
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test('FT-02 - Checking the acknowledgment checkbox enables Submit', async ({
+    page,
+  }) => {
+    const checkbox = getDeletionCheckbox(page);
+    const submitButton = getSubmitButton(page);
+
+    await checkbox.check();
+
+    await expect(checkbox).toBeChecked();
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test('FT-03 - Unchecking the acknowledgment checkbox disables Submit', async ({
+    page,
+  }) => {
+    const checkbox = getDeletionCheckbox(page);
+    const submitButton = getSubmitButton(page);
+
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+    await expect(submitButton).toBeEnabled();
+
+    await checkbox.uncheck();
+
+    await expect(checkbox).not.toBeChecked();
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test('FT-04 - Cancel resets deletion selection and preserves reason text', async ({
+    page,
+  }) => {
+    const reason = 'I no longer need this account.';
+    const textarea = getReasonTextarea(page);
+    const checkbox = getDeletionCheckbox(page);
+    const submitButton = getSubmitButton(page);
+
+    await textarea.fill(reason);
+    await checkbox.check();
+
+    await expect(textarea).toHaveValue(reason);
+    await expect(checkbox).toBeChecked();
+    await expect(submitButton).toBeEnabled();
+
+    await getCancelButton(page).click();
+
+    await expect(checkbox).not.toBeChecked();
+    await expect(submitButton).toBeDisabled();
+    await expect(textarea).toHaveValue(reason);
+
+    await expect(
+      page.getByRole('heading', {
+        name: SIGN_OFF_HEADING,
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+
+  test('BT-01 - Character counter updates dynamically', async ({
+    page,
+  }) => {
+    const tenCharacters = '1234567890';
+    const textarea = getReasonTextarea(page);
+
+    await textarea.fill(tenCharacters);
+
+    await expect(textarea).toHaveValue(tenCharacters);
+    await expect(getCharacterCounter(page)).toHaveText(
+      '10/500 characters'
+    );
+  });
+
+  test('BT-02 - Textarea accepts exactly 500 characters', async ({
+    page,
+  }) => {
+    const fiveHundredCharacters = 'a'.repeat(500);
+    const textarea = getReasonTextarea(page);
+
+    await textarea.fill(fiveHundredCharacters);
+
+    await expect(textarea).toHaveValue(fiveHundredCharacters);
+    await expect(getCharacterCounter(page)).toHaveText(
+      '500/500 characters'
+    );
+  });
+
+  test('BT-03 - Textarea blocks input beyond 500 characters', async ({
+    page,
+  }) => {
+    const fiveHundredFiveCharacters = 'a'.repeat(505);
+    const expectedValue = 'a'.repeat(500);
+    const textarea = getReasonTextarea(page);
+
+    await textarea.fill(fiveHundredFiveCharacters);
+
+    await expect(textarea).toHaveValue(expectedValue);
+    await expect(textarea).toHaveAttribute('maxlength', '500');
+
+    await expect(getCharacterCounter(page)).toHaveText(
+      '500/500 characters'
+    );
+  });
+
+  test('BT-04 - Textarea accepts special characters and emojis safely', async ({
+    page,
+  }) => {
+    const specialText = '!@#$%^&*()_+ Test 😀 🚀';
+    const textarea = getReasonTextarea(page);
+
+    await textarea.fill(specialText);
+
+    await expect(textarea).toHaveValue(specialText);
+
+    await expect(
+      page.getByText(
+        'An error occurred while deleting your account. Please try again.',
+        { exact: true }
+      )
+    ).not.toBeVisible();
+  });
+
+  test('ST-02 - Submit opens the final account deletion confirmation modal', async ({
+    page,
+  }) => {
+    const checkbox = getDeletionCheckbox(page);
+    const submitButton = getSubmitButton(page);
+
+    await checkbox.check();
+
+    await expect(checkbox).toBeChecked();
+    await expect(submitButton).toBeEnabled();
+
+    await submitButton.click();
+
+    const modalHeading = page.getByText(
+      'Confirm Account Deletion',
+      { exact: true }
+    );
+
+    await expect(modalHeading).toBeVisible();
+
+    await expect(
+      page.getByText(
+        /Are you absolutely sure you want to delete your account/i
+      )
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Delete Account',
+        exact: true,
+      })
+    ).toBeVisible();
+
+    const modalCancelButton = page
+      .getByRole('button', {
+        name: 'Cancel',
+        exact: true,
+      })
+      .last();
+
+    await expect(modalCancelButton).toBeVisible();
+    await modalCancelButton.click();
+
+    await expect(modalHeading).not.toBeVisible();
+
+    await expect(
+      page.getByRole('heading', {
+        name: SIGN_OFF_HEADING,
+        exact: true,
+      })
+    ).toBeVisible();
+  });
+});

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,0 +1,48 @@
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  setup.setTimeout(60000);
+
+  const email = process.env.SAAYAM_EMAIL;
+  const password = process.env.SAAYAM_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'SAAYAM_EMAIL and SAAYAM_PASSWORD environment variables are required.'
+    );
+  }
+
+  await page.goto('/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  await page
+    .getByPlaceholder(/email/i)
+    .fill(email);
+
+  await page
+    .getByPlaceholder(/password/i)
+    .fill(password);
+
+  await page
+    .getByRole('button', {
+      name: 'Log In',
+      exact: true,
+    })
+    .last()
+    .click();
+
+  await page.waitForURL(
+    url => !url.pathname.includes('/login'),
+    {
+      timeout: 60000,
+    }
+  );
+
+  await page.context().storageState({
+    path: authFile,
+  });
+});


### PR DESCRIPTION
## Summary
Implemented automated Playwright E2E tests for the Profile → Sign Off page.

### Automated Test Coverage
- FT-01: Verify initial Sign Off page state
- FT-02: Submit enabled after acknowledgment
- FT-03: Submit disabled when acknowledgment is removed
- FT-04: Cancel resets deletion selection while preserving entered reason
- BT-01: Character counter updates correctly
- BT-02: Textarea accepts exactly 500 characters
- BT-03: Input is limited to 500 characters
- BT-04: Special characters and emojis accepted
- ST-02: Account deletion confirmation modal displayed before deletion

### Browser Coverage
- Chromium ✅
- Firefox ✅
- WebKit ✅

### QA Findings
- All automated tests passed successfully across supported browsers.
- Manual testing identified a backend issue where confirming account deletion displays an error message ("An error occurred while deleting your account. Please try again.") and the account remains active. This has been documented as a product defect and was not automated as a passing scenario.

### Report
[Playwright Test Report Issue#53.pdf](https://github.com/user-attachments/files/30562076/Playwright.Test.Report.Issue.53.pdf)
