### PR TITLE
Add Playwright tests for volunteer location updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright generated files
+node_modules/
+playwright-report/
+playwright-report-*/
+test-results/
+playwright/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qa",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "description": "Repository for all the QA related code and documents",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KotamarthiSriharsha/qa.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/KotamarthiSriharsha/qa/issues"
+  },
+  "homepage": "https://github.com/KotamarthiSriharsha/qa#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,58 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+
+  fullyParallel: true,
+
+  timeout: 60000,
+
+  expect: {
+    timeout: 10000,
+  },
+
+  retries: 1,
+
+  reporter: 'list',
+
+  use: {
+    baseURL: 'https://test-saayam.netlify.app',
+    trace: 'on-first-retry',
+    navigationTimeout: 60000,
+    actionTimeout: 15000,
+  },
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,0 +1,48 @@
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  setup.setTimeout(60000);
+
+  const email = process.env.SAAYAM_EMAIL;
+  const password = process.env.SAAYAM_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'SAAYAM_EMAIL and SAAYAM_PASSWORD environment variables are required.'
+    );
+  }
+
+  await page.goto('/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  await page
+    .getByPlaceholder(/email/i)
+    .fill(email);
+
+  await page
+    .getByPlaceholder(/password/i)
+    .fill(password);
+
+  await page
+    .getByRole('button', {
+      name: 'Log In',
+      exact: true,
+    })
+    .last()
+    .click();
+
+  await page.waitForURL(
+    url => !url.pathname.includes('/login'),
+    {
+      timeout: 60000,
+    }
+  );
+
+  await page.context().storageState({
+    path: authFile,
+  });
+});

--- a/tests/update-volunteer-location.spec.js
+++ b/tests/update-volunteer-location.spec.js
@@ -1,0 +1,341 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe.serial(
+  'Update Volunteer Location - Personal Information',
+  () => {
+    const updatedLocation = {
+      streetAddress: '2520 Avent Ferry Road',
+      streetAddress2: 'apt 207',
+      city: 'Raleigh',
+      state: 'North Carolina',
+      zipCode: '27606',
+    };
+
+    async function openPersonalInformation(page) {
+      await page.goto('/profile', {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+      });
+
+      await expect(page).toHaveURL(/profile/i);
+
+      await page
+        .getByRole('button', {
+          name: 'Personal Information',
+          exact: true,
+        })
+        .last()
+        .click();
+
+      await expect(
+        page.getByText('Street Address', { exact: true })
+      ).toBeVisible({
+        timeout: 20000,
+      });
+    }
+
+    async function enterEditMode(page) {
+      const editButton = page.getByRole('button', {
+        name: /^edit$/i,
+      });
+
+      await expect(editButton).toBeVisible({
+        timeout: 20000,
+      });
+
+      await editButton.click();
+
+      await expect(
+        page.locator('input[name="streetAddress"]')
+      ).toBeVisible({
+        timeout: 20000,
+      });
+
+      await expect(
+        page.getByRole('button', {
+          name: /^save$/i,
+        })
+      ).toBeVisible();
+    }
+
+    async function selectState(page, stateName) {
+      const stateInput = page.locator('#react-select-3-input');
+
+      await stateInput.click();
+      await stateInput.fill(stateName);
+
+      const stateOption = page.getByRole('option', {
+        name: stateName,
+        exact: true,
+      });
+
+      await expect(stateOption).toBeVisible({
+        timeout: 10000,
+      });
+
+      await stateOption.click();
+    }
+
+    async function fillLocationForm(page) {
+      await page
+        .locator('input[name="streetAddress"]')
+        .fill(updatedLocation.streetAddress);
+
+      await page
+        .locator('input[name="streetAddress2"]')
+        .fill(updatedLocation.streetAddress2);
+
+      await page
+        .locator('input[name="city"]')
+        .fill(updatedLocation.city);
+
+      await selectState(page, updatedLocation.state);
+
+      await page
+        .locator('input[name="zipCode"]')
+        .fill(updatedLocation.zipCode);
+    }
+
+    async function verifySavedLocation(page) {
+      await expect(
+        page.getByText(updatedLocation.streetAddress, {
+          exact: true,
+        })
+      ).toBeVisible({
+        timeout: 20000,
+      });
+
+      await expect(
+        page.getByText(updatedLocation.streetAddress2, {
+          exact: true,
+        })
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(updatedLocation.city, {
+          exact: true,
+        })
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(updatedLocation.state, {
+          exact: true,
+        })
+      ).toBeVisible();
+
+      await expect(
+        page.getByText(updatedLocation.zipCode, {
+          exact: true,
+        })
+      ).toBeVisible();
+    }
+
+    test.beforeEach(async ({ page }) => {
+      await openPersonalInformation(page);
+    });
+
+    test(
+      'TC_LOC_001 - Personal Information displays volunteer location fields',
+      async ({ page }) => {
+        await expect(
+          page.getByText('Street Address', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByText('Street Address 2', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByText('City', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByText('State', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByText('Country', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByText('Zip Code', { exact: true })
+        ).toBeVisible();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^edit$/i,
+          })
+        ).toBeVisible();
+      }
+    );
+
+    test(
+      'TC_LOC_002 - Edit opens editable volunteer location fields',
+      async ({ page }) => {
+        await enterEditMode(page);
+
+        await expect(
+          page.locator('input[name="streetAddress"]')
+        ).toBeVisible();
+
+        await expect(
+          page.locator('input[name="streetAddress2"]')
+        ).toBeVisible();
+
+        await expect(
+          page.locator('input[name="city"]')
+        ).toBeVisible();
+
+        await expect(
+          page.locator('#react-select-3-input')
+        ).toBeVisible();
+
+        const countryInput = page.locator('#react-select-4-input');
+
+        await expect(countryInput).toBeDisabled();
+
+        await expect(
+          page.locator('input[name="zipCode"]')
+        ).toBeVisible();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^save$/i,
+          })
+        ).toBeVisible();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^cancel$/i,
+          })
+        ).toBeVisible();
+      }
+    );
+
+    test(
+      'TC_LOC_003 - Cancel discards unsaved location changes',
+      async ({ page }) => {
+        await enterEditMode(page);
+
+        const streetAddress = page.locator(
+          'input[name="streetAddress"]'
+        );
+
+        const temporaryAddress = '999 Temporary Test Address';
+
+        await streetAddress.fill(temporaryAddress);
+
+        await expect(streetAddress).toHaveValue(
+          temporaryAddress
+        );
+
+        await page
+          .getByRole('button', {
+            name: /^cancel$/i,
+          })
+          .click();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^edit$/i,
+          })
+        ).toBeVisible({
+          timeout: 20000,
+        });
+
+        await expect(
+          page.getByText(temporaryAddress, {
+            exact: true,
+          })
+        ).toHaveCount(0);
+      }
+    );
+
+    test(
+      'TC_LOC_004 - Volunteer can update and save location information',
+      async ({ page }) => {
+        await enterEditMode(page);
+
+        await fillLocationForm(page);
+
+        await expect(
+          page.locator('input[name="streetAddress"]')
+        ).toHaveValue(updatedLocation.streetAddress);
+
+        await expect(
+          page.locator('input[name="streetAddress2"]')
+        ).toHaveValue(updatedLocation.streetAddress2);
+
+        await expect(
+          page.locator('input[name="city"]')
+        ).toHaveValue(updatedLocation.city);
+
+        await expect(
+          page.locator('input[name="zipCode"]')
+        ).toHaveValue(updatedLocation.zipCode);
+
+        await page
+          .getByRole('button', {
+            name: /^save$/i,
+          })
+          .click();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^edit$/i,
+          })
+        ).toBeVisible({
+          timeout: 20000,
+        });
+
+        await verifySavedLocation(page);
+      }
+    );
+
+    test(
+      'TC_LOC_005 - Saved volunteer location persists after refresh',
+      async ({ page }) => {
+        await enterEditMode(page);
+
+        await fillLocationForm(page);
+
+        await page
+          .getByRole('button', {
+            name: /^save$/i,
+          })
+          .click();
+
+        await expect(
+          page.getByRole('button', {
+            name: /^edit$/i,
+          })
+        ).toBeVisible({
+          timeout: 20000,
+        });
+
+        await page.reload({
+          waitUntil: 'domcontentloaded',
+          timeout: 60000,
+        });
+
+        await page
+          .getByRole('button', {
+            name: 'Personal Information',
+            exact: true,
+          })
+          .last()
+          .click();
+
+        await expect(
+          page.getByText('Street Address', {
+            exact: true,
+          })
+        ).toBeVisible({
+          timeout: 20000,
+        });
+
+        await verifySavedLocation(page);
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Summary

This PR adds Playwright end-to-end tests for updating volunteer location information in the Personal Information section of the volunteer profile.

### Test Coverage

- Verify Personal Information displays volunteer location fields.
- Verify Edit mode enables volunteer location fields.
- Verify Cancel discards unsaved location changes.
- Verify volunteers can update and save location information.
- Verify saved location persists after a page refresh.

### Implementation Details

- Added a dedicated Playwright test suite for volunteer location updates.
- Reused the existing authentication setup for authenticated test execution.
- Used Playwright locators for editable input fields and React Select components.
- Validated persistence of updated location information after refreshing the page.

### Validation

Tested successfully on:
- Chromium
- Firefox
- WebKit

All automated tests passed successfully.
[Playwright Test Report Issue#71.pdf](https://github.com/user-attachments/files/30808776/Playwright.Test.Report.Issue.71.pdf)
