### PR TITLE
Add Playwright tests for WhatsApp communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright generated files
+node_modules/
+playwright-report/
+playwright-report-*/
+test-results/
+playwright/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qa",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "qa",
+  "version": "1.0.0",
+  "description": "Repository for all the QA related code and documents",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KotamarthiSriharsha/qa.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/KotamarthiSriharsha/qa/issues"
+  },
+  "homepage": "https://github.com/KotamarthiSriharsha/qa#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,58 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+
+  fullyParallel: true,
+
+  timeout: 60000,
+
+  expect: {
+    timeout: 10000,
+  },
+
+  retries: 1,
+
+  reporter: 'list',
+
+  use: {
+    baseURL: 'https://test-saayam.netlify.app',
+    trace: 'on-first-retry',
+    navigationTimeout: 60000,
+    actionTimeout: 15000,
+  },
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.js/,
+    },
+
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,0 +1,48 @@
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  setup.setTimeout(60000);
+
+  const email = process.env.SAAYAM_EMAIL;
+  const password = process.env.SAAYAM_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'SAAYAM_EMAIL and SAAYAM_PASSWORD environment variables are required.'
+    );
+  }
+
+  await page.goto('/login', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+
+  await page
+    .getByPlaceholder(/email/i)
+    .fill(email);
+
+  await page
+    .getByPlaceholder(/password/i)
+    .fill(password);
+
+  await page
+    .getByRole('button', {
+      name: 'Log In',
+      exact: true,
+    })
+    .last()
+    .click();
+
+  await page.waitForURL(
+    url => !url.pathname.includes('/login'),
+    {
+      timeout: 60000,
+    }
+  );
+
+  await page.context().storageState({
+    path: authFile,
+  });
+});

--- a/tests/whatsapp-communication.spec.js
+++ b/tests/whatsapp-communication.spec.js
@@ -1,0 +1,214 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe(
+  'Issue #72 - Communication with Users through WhatsApp',
+  () => {
+
+    async function openProfile(page) {
+      await page.goto('/profile', {
+        waitUntil: 'domcontentloaded',
+      });
+
+      await expect(page).toHaveURL(/\/profile/);
+
+      await expect(
+        page.getByText('Phone Number', { exact: true })
+      ).toBeVisible();
+    }
+
+
+    function getWhatsAppIcon(page) {
+      return page.getByRole('img', {
+        name: 'WhatsApp',
+      });
+    }
+
+
+    test(
+      'TC-001 - WhatsApp text icon is visible on the user profile page',
+      async ({ page }) => {
+
+        await openProfile(page);
+
+        const whatsappIcon = getWhatsAppIcon(page);
+
+        await expect(whatsappIcon).toBeVisible();
+      }
+    );
+
+
+    test(
+      'TC-002 - Clicking WhatsApp icon opens WhatsApp chat with user number',
+      async ({ page }) => {
+
+        await openProfile(page);
+
+        const whatsappIcon = getWhatsAppIcon(page);
+
+        await expect(whatsappIcon).toBeVisible();
+
+        /*
+         * Clicking the WhatsApp image opens a new tab.
+         */
+        const [whatsappPage] = await Promise.all([
+          page.waitForEvent('popup'),
+          whatsappIcon.click(),
+        ]);
+
+        await whatsappPage.waitForLoadState(
+          'domcontentloaded'
+        );
+
+        /*
+         * Verify that WhatsApp was opened.
+         */
+        await expect(whatsappPage).toHaveURL(
+          /api\.whatsapp\.com|web\.whatsapp\.com|wa\.me/i
+        );
+
+        /*
+         * Verify that WhatsApp opened a chat target.
+         *
+         * The user does not need to already be logged
+         * into WhatsApp Web for this validation.
+         */
+        await expect(
+          whatsappPage.getByText(
+            /Chat on WhatsApp with/i
+          )
+        ).toBeVisible();
+
+        await whatsappPage.close();
+      }
+    );
+
+
+    test.skip(
+      'TC-003 - WhatsApp call button is visible on the user profile page',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * Separate WhatsApp voice-call control is not
+         * currently available on the Saayam profile page.
+         */
+      }
+    );
+
+
+    test.skip(
+      'TC-004 - Clicking WhatsApp call button initiates a WhatsApp voice call',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * WhatsApp voice-call functionality cannot
+         * currently be validated through the Saayam UI.
+         */
+      }
+    );
+
+
+    test.skip(
+      'TC-005 - WhatsApp video button is visible on the user profile page',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * Separate WhatsApp video-call control is not
+         * currently available on the Saayam profile page.
+         */
+      }
+    );
+
+
+    test.skip(
+      'TC-006 - Clicking WhatsApp video button initiates a WhatsApp video call',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * WhatsApp video-call functionality cannot
+         * currently be validated through the Saayam UI.
+         */
+      }
+    );
+
+
+    test.skip(
+      'TC-007 - WhatsApp options unavailable when user has no phone number',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * Requires a known test profile without
+         * a registered phone number.
+         */
+      }
+    );
+
+
+    test.skip(
+      'TC-008 - Unassigned volunteer cannot see WhatsApp communication controls',
+      async () => {
+        /*
+         * ON HOLD
+         *
+         * Requires:
+         * - a request assigned to another volunteer
+         * - credentials for an unassigned volunteer
+         */
+      }
+    );
+
+
+    test(
+      'TC-009 - Unauthenticated user cannot access WhatsApp communication options',
+      async ({ browser }) => {
+
+        const context = await browser.newContext();
+
+        const page = await context.newPage();
+
+        await page.goto(
+          'https://test-saayam.netlify.app/profile',
+          {
+            waitUntil: 'domcontentloaded',
+          }
+        );
+
+        /*
+         * Expected behavior according to TC-009:
+         * unauthenticated users should be redirected
+         * to the login page.
+         *
+         * Current observed application behavior stays
+         * on /profile, so this test may legitimately fail.
+         */
+        await expect(page).toHaveURL(/login/i);
+
+        const whatsappIcon = page.getByRole('img', {
+          name: 'WhatsApp',
+        });
+
+        await expect(whatsappIcon).toHaveCount(0);
+
+        await context.close();
+      }
+    );
+
+
+    test(
+      'TC-010 - WhatsApp text option works across supported browsers',
+      async ({ page }) => {
+
+        await openProfile(page);
+
+        const whatsappIcon = getWhatsAppIcon(page);
+
+        await expect(whatsappIcon).toBeVisible();
+      }
+    );
+
+  }
+);


### PR DESCRIPTION
## Summary

Added Playwright automated tests for the "Communication With Users
(text, call, video through WhatsApp)" functionality.

## Changes

- Added Playwright configuration for Chromium, Firefox, and WebKit.
- Added authentication setup using environment variables.
- Added automated validation for the WhatsApp communication feature.
- Verified that the WhatsApp icon is visible on the user profile.
- Verified that clicking the WhatsApp icon opens the corresponding
  WhatsApp chat in a new tab.
- Added cross-browser validation for Chromium, Firefox, and WebKit.
- Kept unavailable voice/video call scenarios on hold.
- Kept scenarios requiring unavailable test data on hold.

## Test Results

Full cross-browser execution:

- 10 passed
- 18 skipped
- 3 failed

The 3 failures correspond to the same test case (TC-009) executed on
Chromium, Firefox, and WebKit.

### QA Finding - TC-009

TC-009 verifies that an unauthenticated user attempting to access the
profile/WhatsApp communication functionality is redirected to the login
page.

Current behavior:

`https://test-saayam.netlify.app/profile`

remains accessible instead of redirecting to `/login`.

This behavior was reproduced consistently on:

- Chromium
- Firefox
- WebKit

The test has intentionally been left failing to document the difference between the expected and actual application behavior.

## On Hold

TC-003 through TC-006:
WhatsApp voice and video call functionality is currently unavailable.

TC-007:
Requires a test profile without a registered phone number.

TC-008:
Requires assigned and unassigned volunteer test data.

[Playwright Test Report Issue#72.pdf](https://github.com/user-attachments/files/31111839/Playwright.Test.Report.Issue.72.pdf)